### PR TITLE
Bugfix `computeObject` null handling.

### DIFF
--- a/utils/compute.js
+++ b/utils/compute.js
@@ -13,7 +13,12 @@ function computeObject (object) {
 	Object.keys(object).forEach((key) => {
 		const value = object[key];
 
-		mapped[key] = typeof value === "object" ? computeObject(value) : compute(value);
+		if (value === null) {
+			mapped[key] = null;
+		}
+		else {
+			mapped[key] = typeof value === "object" ? computeObject(value) : compute(value);
+		}
 	});
 
 	return mapped;


### PR DESCRIPTION
Since `null` is an object, this method would try to call `Object.keys` on `null`, causing an error.
