### PR TITLE
Add request method

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,4 +8,4 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = tab
-tab_width = 4
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ client.add(
 );
 ```
 
+**request**
+
+`request` is a fetch-like API with support for middlewares and a configured endpoint.
+
+```js
+client.request("posts/25/comments", {
+	method: "POST",
+	body: {comment: "C-3PO"}
+});
+
 **handlers**
 
 Handlers take configuration and return functions to pass to `.then()`.

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -83,6 +83,10 @@ async function main () {
 	await api.browse(["posts", 8, "comments"]).then(renderJSON);
 	await api.browse(["posts", 9, "comments", 9]).catch((e) => console.warn(e)); // warning cannot "browse" single record
 	await api.read(["posts", 10, "comments", 10], {query:{_limit: 1}}).catch((e) => console.error(e.status)); // 404
+	
+	// Fetch-like API with configured middlewares and endpoint
+	await api.request("posts/1", {method: "GET"}).then(renderJSON);
+	await api.request("posts/1", {method: "PUT", body: {title: 'foo', body: 'bar', userId: 4}}).then(renderJSON);
 }
 
 main();

--- a/packages/fetch-plus/src/index.js
+++ b/packages/fetch-plus/src/index.js
@@ -15,6 +15,7 @@ function connectEndpoint (url, options = {}, middlewares = []) {
 		middlewares: {}
 	};
 
+	endpoint.request = request.bind(null, endpoint);
 	endpoint.browse  = browse.bind(null, endpoint);
 	endpoint.read    = read.bind(null, endpoint);
 	endpoint.edit    = edit.bind(null, endpoint);
@@ -190,6 +191,10 @@ function _expectOdd (array) {
 	return array;
 }
 
+function request (_endpoint, path, options = {}, middlewares = []) {
+	return _callFetch(_endpoint, path, {action: "request", ...options}, middlewares);
+}
+
 function browse (_endpoint, path, options = {}, middlewares = []) {
 	return _callFetch(_endpoint, () => _expectOdd(path), {action: "browse", method: "GET", ...options}, middlewares);
 }
@@ -227,6 +232,7 @@ module.exports = {
 	addMiddleware,
 	removeMiddleware,
 	fetch: _dropInFetch,
+	request,
 	browse,
 	read,
 	edit,


### PR DESCRIPTION
I've added a method `request` which is a fetch-like API with support for middlewares and a configured endpoint. Use it if you don't want to use the BREAD/CRUD methods.

``` js
import fetch from "isomorphic-fetch";
import fetchPlus from "fetch-plus";
import plusJson from "fetch-plus-json";

const api = fetchPlus.connectEndpoint("http://jsonplaceholder.typicode.com");

// Add JSON headers and response transformer.
api.addMiddleware(plusJson());

// PUT http://jsonplaceholder.typicode.com/posts/1
api.request("posts/1", {
  method: "PUT", 
  body: {title: 'foo', body: 'bar', userId: 4}
}).then((response) => console.log(response));
```
