### PR TITLE
trimPathSlashes option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "immutable": "3.8.1",
+    "query-string": "^4.2.3",
     "xml2js": "^0.4.16"
   },
   "devDependencies": {

--- a/packages/fetch-plus/src/index.js
+++ b/packages/fetch-plus/src/index.js
@@ -38,6 +38,7 @@ const createClient = (url, options = {}, middlewares = []) => {
 		middlewares.forEach(endpoint.addMiddleware);
 	}
 
+	endpoint.options.trimPathSlashes = options.trimPathSlashes === undefined ? true : options.trimPathSlashes;
 	return endpoint;
 };
 
@@ -79,7 +80,10 @@ const _callFetch = (endpoint, path = "", options = {}, middlewares = []) => {
 			path = [path];
 		}
 
-		path = _trimSlashes(path.map(compute).map(encodeURI).join("/"));
+		path = path.map(compute).map(encodeURI).join("/");
+		if (endpoint.options.trimPathSlashes) {
+			path = _trimSlashes(path);
+		}
 
 		if (path) {
 			path = "/" + path;


### PR DESCRIPTION
I was trying to use  `fetch-plus` with a third party API that ends all of their URLs with `/`.
Because of the `_trimSlashes` function I was having some troubles to use this API.
So this PR is about having an explicit option to disable `trimSlashes` call (for paths but not for URLs).
