### PR TITLE
Feature/add preserve trailing slash option

### DIFF
--- a/packages/fetch-plus/package.json
+++ b/packages/fetch-plus/package.json
@@ -25,5 +25,8 @@
   "scripts": {
     "build": "webpack --verbose --colors --display-error-details --config ../../webpack.umd.js ./src/index.js ./dist/index.js  --output-library=fetch-plus",
     "prepublish": "npm run build"
+  },
+  "dependencies": {
+    "query-string": "^4.2.3"
   }
 }

--- a/packages/fetch-plus/src/index.js
+++ b/packages/fetch-plus/src/index.js
@@ -4,8 +4,9 @@
 import queryString from "query-string";
 import {compute, computeObject} from "utils/compute";
 
-const _trimSlashes = (string) => {
-	return string.toString().replace(/(^\/+|\/+$)/g, "");
+const _trimSlashes = (string, preserveTrailingSlash) => {
+	const pattern = preserveTrailingSlash ? /(^\/+)/g : /(^\/+|\/+$)/g;
+	return string.toString().replace(pattern, "");
 };
 
 const createClient = (url, options = {}, middlewares = []) => {
@@ -38,6 +39,7 @@ const createClient = (url, options = {}, middlewares = []) => {
 		middlewares.forEach(endpoint.addMiddleware);
 	}
 
+	endpoint.options.preserveTrailingSlash = options.preserveTrailingSlash === undefined ? false : options.preserveTrailingSlash;
 	return endpoint;
 };
 
@@ -79,7 +81,7 @@ const _callFetch = (endpoint, path = "", options = {}, middlewares = []) => {
 			path = [path];
 		}
 
-		path = _trimSlashes(path.map(compute).map(encodeURI).join("/"));
+		path = _trimSlashes(path.map(compute).map(encodeURI).join("/"), endpoint.options.preserveTrailingSlash);
 
 		if (path) {
 			path = "/" + path;


### PR DESCRIPTION
A similar approach to PR #27, but using a preserveTrailingSlash endpoint option to be able to control the slash replacement logic.

Previously a path of `/my/path/` would ultimately be requested as `/my/path`.

This is still the default behavior, but now using the `preserveTrailingSlash` option the trailing slash will be preserved.