### PR TITLE
Support async error handlers

### DIFF
--- a/packages/fetch-plus/src/index.js
+++ b/packages/fetch-plus/src/index.js
@@ -169,22 +169,13 @@ const _callFetch = (endpoint, path = "", options = {}, middlewares = []) => {
 			throw error;
 		}
 
-		let recovered = null;
+		let promise = Promise.reject(error);
 
-		errorMiddlewares.some((errorMiddleware) => {
-			try {
-				return recovered = errorMiddleware(error);
-			}
-			catch (e) {
-				error = e;
-			}
+		errorMiddlewares.forEach((errorMiddleware) => {
+			promise = promise.catch(errorMiddleware)
 		});
 
-		if (recovered) {
-			return recovered;
-		}
-
-		throw error;
+		return promise;
 	});
 };
 


### PR DESCRIPTION
I needed this because I want to be able to do get the error response with `errorResponse.text()` and put it in the error message. It could also help in other middleware if they need to fire off a second request the first one fails etc. It should be backwards compatible. Usages:

```js
error: (resp) => {
  console.error(resp);
  throw resp;
}
```

```js
error: (resp) => {
  console.error(resp);
  return Promise.reject(resp);
}
```

```js
error: (resp) => {
  console.error(resp);
  return resp.text().then(text => { 
    throw { ...resp, errorText: text };
  });
}
```

```js
error: (resp) => {
  console.error(resp);
  return new Promise(resolve => {
    // Resolve after 1 second
    setTimeout(() => {
      resolve({ something: {} });
    }, 1000);
  });
}
```